### PR TITLE
fix(deleteby): refine error message for multiple matches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'jacoco'
 }
 
-mainClassName = 'seedu.address.Main'
+mainClassName = 'trackup.Main'
 
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/trackup/logic/Messages.java
+++ b/src/main/java/trackup/logic/Messages.java
@@ -19,6 +19,10 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 
+    public static final String MESSAGE_MULTIPLE_PEOPLE_TO_DELETE =
+            "Multiple contacts match the provided attributes: %s. Please refine your input to uniquely identify a contact.";
+
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/trackup/logic/Messages.java
+++ b/src/main/java/trackup/logic/Messages.java
@@ -20,8 +20,8 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
 
     public static final String MESSAGE_MULTIPLE_PEOPLE_TO_DELETE =
-            "Multiple contacts match the provided attributes: %s. Please refine your input to uniquely identify a contact.";
-
+            "Multiple contacts match the provided attributes: %s. "
+                    + "Please refine your input to uniquely identify a contact.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/trackup/logic/commands/DeleteByCommand.java
+++ b/src/main/java/trackup/logic/commands/DeleteByCommand.java
@@ -1,6 +1,7 @@
 package trackup.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static trackup.logic.Messages.MESSAGE_MULTIPLE_PEOPLE_TO_DELETE;
 import static trackup.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static trackup.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static trackup.logic.parser.CliSyntax.PREFIX_NAME;
@@ -47,8 +48,6 @@ public class DeleteByCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_NO_PERSON_TO_DELETE = "No Person Matches Criteria: %1$s";
-    public static final String MESSAGE_MULTIPLE_PEOPLE_TO_DELETE =
-            "Multiple contacts match the provided attributes. Please refine your input to uniquely identify a contact.";
     public static final String MESSAGE_NO_CRITERIA_SPECIFIED = "At least one field to edit must be provided.";
 
     private final Optional<Name> deleteByName;
@@ -131,7 +130,7 @@ public class DeleteByCommand extends Command {
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
         } else {
             model.updateFilteredPersonList(predicate);
-            return new CommandResult(MESSAGE_MULTIPLE_PEOPLE_TO_DELETE);
+            return new CommandResult(String.format(MESSAGE_MULTIPLE_PEOPLE_TO_DELETE, this.toString()));
         }
     }
 

--- a/src/main/java/trackup/logic/commands/DeleteByCommand.java
+++ b/src/main/java/trackup/logic/commands/DeleteByCommand.java
@@ -47,7 +47,8 @@ public class DeleteByCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_NO_PERSON_TO_DELETE = "No Person Matches Criteria: %1$s";
-    public static final String MESSAGE_MULTIPLE_PEOPLE_TO_DELETE = "Multiple People Matches Criteria: %1$s";
+    public static final String MESSAGE_MULTIPLE_PEOPLE_TO_DELETE =
+            "Multiple contacts match the provided attributes. Please refine your input to uniquely identify a contact.";
     public static final String MESSAGE_NO_CRITERIA_SPECIFIED = "At least one field to edit must be provided.";
 
     private final Optional<Name> deleteByName;
@@ -130,7 +131,7 @@ public class DeleteByCommand extends Command {
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
         } else {
             model.updateFilteredPersonList(predicate);
-            return new CommandResult(String.format(MESSAGE_MULTIPLE_PEOPLE_TO_DELETE, this.toString()));
+            return new CommandResult(MESSAGE_MULTIPLE_PEOPLE_TO_DELETE);
         }
     }
 

--- a/src/main/java/trackup/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/trackup/logic/commands/exceptions/CommandException.java
@@ -1,5 +1,7 @@
 package trackup.logic.commands.exceptions;
 
+import trackup.logic.commands.Command;
+
 /**
  * Represents an error which occurs during execution of a {@link Command}.
  */

--- a/src/main/java/trackup/logic/parser/FindCommandParser.java
+++ b/src/main/java/trackup/logic/parser/FindCommandParser.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import trackup.logic.commands.FindCommand;
 import trackup.logic.parser.exceptions.ParseException;
+import trackup.model.person.Name;
 import trackup.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -27,7 +28,15 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
+        // Validate each keyword using Name.isValidName()
+        for (String keyword : nameKeywords) {
+            if (!Name.isValidName(keyword)) {
+                throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            }
+        }
+
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
+
 
 }

--- a/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
+++ b/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
@@ -152,7 +152,10 @@ public class DeleteByCommandTest {
 
         CommandResult commandResult = deleteCommand.execute(model);
 
-        assertEquals(DeleteByCommand.MESSAGE_MULTIPLE_PEOPLE_TO_DELETE, commandResult.getFeedbackToUser());
+        assertEquals(
+                String.format(Messages.MESSAGE_MULTIPLE_PEOPLE_TO_DELETE, deleteCommand.toString()),
+                commandResult.getFeedbackToUser()
+        );
     }
 
     @Test

--- a/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
+++ b/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
@@ -152,8 +152,7 @@ public class DeleteByCommandTest {
 
         CommandResult commandResult = deleteCommand.execute(model);
 
-        assertEquals(String.format(DeleteByCommand.MESSAGE_MULTIPLE_PEOPLE_TO_DELETE,
-                deleteCommand.toString()), commandResult.getFeedbackToUser());
+        assertEquals(DeleteByCommand.MESSAGE_MULTIPLE_PEOPLE_TO_DELETE, commandResult.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/trackup/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/trackup/logic/parser/FindCommandParserTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import trackup.logic.commands.FindCommand;
+import trackup.model.person.Name;
 import trackup.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -30,5 +31,12 @@ public class FindCommandParserTest {
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
+
+    @Test
+    public void parse_invalidNameWithQuotes_throwsParseException() {
+        String invalidInput = "\"John\""; // the quotes make the name invalid
+        assertParseFailure(parser, invalidInput, Name.MESSAGE_CONSTRAINTS);
+    }
+
 
 }


### PR DESCRIPTION
This PR improves the error message displayed when the deleteby command finds multiple contacts matching the provided attributes. 

Previously, the output was:
"Multiple People Matches Criteria: trackup.logic.commands.DeleteByCommand{phone=90112233}"

Now, it displays a clear message:
"Multiple contacts match the provided attributes. Please refine your input to uniquely identify a contact."

Changes include:
- Updating MESSAGE_MULTIPLE_PEOPLE_TO_DELETE in DeleteByCommand.java.
- Modifying the execute method to return the new message.
- Updating the corresponding test in DeleteByCommandTest.java.

Fixes the alpha-bug regarding unclear messages for multiple matches.

Closes issue #117 