### PR TITLE
fix: Edit DeleteByCommand to handle person linked to event being deleted

### DIFF
--- a/src/main/java/trackup/logic/commands/DeleteByCommand.java
+++ b/src/main/java/trackup/logic/commands/DeleteByCommand.java
@@ -8,14 +8,17 @@ import static trackup.logic.parser.CliSyntax.PREFIX_PHONE;
 import static trackup.logic.parser.CliSyntax.PREFIX_TAG;
 import static trackup.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import trackup.commons.util.ToStringBuilder;
 import trackup.logic.Messages;
 import trackup.logic.commands.exceptions.CommandException;
 import trackup.model.Model;
+import trackup.model.event.Event;
 import trackup.model.person.Address;
 import trackup.model.person.Email;
 import trackup.model.person.Name;
@@ -126,6 +129,20 @@ public class DeleteByCommand extends Command {
             throw new CommandException(String.format(MESSAGE_NO_PERSON_TO_DELETE, this.toString()));
         } else if (filteredList.size() == 1) {
             Person personToDelete = filteredList.get(0);
+
+            // Update all events linked to this contact
+            List<Event> allEvents = model.getEventList();
+            for (Event event : allEvents) {
+                if (event.getContacts().contains(personToDelete)) {
+                    Set<Person> updatedContacts = new HashSet<>(event.getContacts());
+                    updatedContacts.remove(personToDelete);
+
+                    Event updatedEvent = new Event(event.getTitle(), event.getStartDateTime(),
+                            event.getEndDateTime(), updatedContacts);
+                    model.setEvent(event, updatedEvent);
+                }
+            }
+
             model.deletePerson(personToDelete);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
         } else {

--- a/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
+++ b/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
@@ -16,24 +16,24 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import javafx.collections.ObservableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import trackup.commons.util.ToStringBuilder;
 import trackup.logic.Messages;
 import trackup.logic.commands.exceptions.CommandException;
 import trackup.model.Model;
+import trackup.model.event.Event;
 import trackup.model.person.Address;
 import trackup.model.person.Email;
 import trackup.model.person.Name;
 import trackup.model.person.Person;
 import trackup.model.person.Phone;
 import trackup.model.tag.Tag;
-import trackup.model.event.Event;
 import trackup.testutil.PersonBuilder;
 
 public class DeleteByCommandTest {

--- a/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
+++ b/src/test/java/trackup/logic/commands/DeleteByCommandTest.java
@@ -10,10 +10,13 @@ import static org.mockito.Mockito.when;
 import static trackup.testutil.Assert.assertThrows;
 import static trackup.testutil.TypicalPersons.ALICE;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import javafx.collections.ObservableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -30,12 +33,22 @@ import trackup.model.person.Name;
 import trackup.model.person.Person;
 import trackup.model.person.Phone;
 import trackup.model.tag.Tag;
+import trackup.model.event.Event;
 import trackup.testutil.PersonBuilder;
 
 public class DeleteByCommandTest {
 
+    private static final String TITLE_MEETING = "Team Meeting";
+    private static final LocalDateTime START = LocalDateTime.of(2024, 5, 1, 10, 0);
+    private static final LocalDateTime END = LocalDateTime.of(2024, 5, 1, 12, 0);
+    private static final LocalDateTime DIFFERENT_START = LocalDateTime.of(2024, 5, 2, 10, 0);
+    private static final LocalDateTime DIFFERENT_END = LocalDateTime.of(2024, 5, 2, 12, 0);
+
     @Mock
     private Model model;
+
+    @Mock
+    private Event event;
 
     @BeforeEach
     public void setUp() {
@@ -52,6 +65,9 @@ public class DeleteByCommandTest {
     public void execute_personFound_success() throws Exception {
         when(model.getFilteredPersonList()).thenReturn(FXCollections.observableArrayList(ALICE));
         when(model.hasPerson(ALICE)).thenReturn(true);
+        List<Event> eventList = List.of();
+        ObservableList<Event> observableEventList = FXCollections.observableArrayList(eventList);
+        when(model.getEventList()).thenReturn(observableEventList);
 
         DeleteByCommand deleteCommand = new DeleteByCommand(
                 Optional.of(ALICE.getName()), Optional.empty(), Optional.empty(),
@@ -68,6 +84,9 @@ public class DeleteByCommandTest {
     public void execute_deleteByPhone_success() throws Exception {
         when(model.getFilteredPersonList()).thenReturn(FXCollections.observableArrayList(ALICE));
         when(model.hasPerson(ALICE)).thenReturn(true);
+        List<Event> eventList = List.of();
+        ObservableList<Event> observableEventList = FXCollections.observableArrayList(eventList);
+        when(model.getEventList()).thenReturn(observableEventList);
 
         DeleteByCommand deleteCommand = new DeleteByCommand(
                 Optional.empty(), Optional.of(ALICE.getPhone()), Optional.empty(),
@@ -84,6 +103,9 @@ public class DeleteByCommandTest {
     public void execute_deleteByEmail_success() throws Exception {
         when(model.getFilteredPersonList()).thenReturn(FXCollections.observableArrayList(ALICE));
         when(model.hasPerson(ALICE)).thenReturn(true);
+        List<Event> eventList = List.of();
+        ObservableList<Event> observableEventList = FXCollections.observableArrayList(eventList);
+        when(model.getEventList()).thenReturn(observableEventList);
 
         DeleteByCommand deleteCommand = new DeleteByCommand(
                 Optional.empty(), Optional.empty(), Optional.of(ALICE.getEmail()),
@@ -100,6 +122,14 @@ public class DeleteByCommandTest {
     public void execute_deleteByAddress_success() throws Exception {
         when(model.getFilteredPersonList()).thenReturn(FXCollections.observableArrayList(ALICE));
         when(model.hasPerson(ALICE)).thenReturn(true);
+        when(event.getContacts()).thenReturn(Set.of(ALICE));
+        when(event.getTitle()).thenReturn(TITLE_MEETING);
+        when(event.getStartDateTime()).thenReturn(START);
+        when(event.getEndDateTime()).thenReturn(END);
+        when(event.getContacts()).thenReturn(Set.of(ALICE));
+        List<Event> eventList = List.of(event);
+        ObservableList<Event> observableEventList = FXCollections.observableArrayList(eventList);
+        when(model.getEventList()).thenReturn(observableEventList);
 
         DeleteByCommand deleteCommand = new DeleteByCommand(
                 Optional.empty(), Optional.empty(), Optional.empty(),
@@ -117,6 +147,9 @@ public class DeleteByCommandTest {
         Tag tag = ALICE.getTags().iterator().next();
         when(model.getFilteredPersonList()).thenReturn(FXCollections.observableArrayList(ALICE));
         when(model.hasPerson(ALICE)).thenReturn(true);
+        List<Event> eventList = List.of();
+        ObservableList<Event> observableEventList = FXCollections.observableArrayList(eventList);
+        when(model.getEventList()).thenReturn(observableEventList);
 
         DeleteByCommand deleteCommand = new DeleteByCommand(
                 Optional.empty(), Optional.empty(), Optional.empty(),


### PR DESCRIPTION
Closes #112 

- Edits execute command to delete all events linked to the contact being deleted by DeleteByCommand
- Needs to work on DeleteByCommandTest