### PR TITLE
fix: Edit SearchCommand to display suitable message for no matches

### DIFF
--- a/src/main/java/trackup/logic/commands/SearchCommand.java
+++ b/src/main/java/trackup/logic/commands/SearchCommand.java
@@ -22,6 +22,7 @@ public class SearchCommand extends Command {
             + "Example: " + COMMAND_WORD + " John";
 
     public static final String MESSAGE_SUCCESS = "Listed persons matching: %1$s";
+    public static final String MESSAGE_NO_MATCH = "No matching person found with: %1$s";
 
     private final String keyword;
 
@@ -56,6 +57,11 @@ public class SearchCommand extends Command {
                         .contains(lowerKeyword));
 
         model.updateFilteredPersonList(matchesKeyword);
+
+        if (model.getFilteredPersonList().isEmpty()) {
+            return new CommandResult(String.format(MESSAGE_NO_MATCH, keyword));
+        }
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, keyword));
     }
 

--- a/src/test/java/trackup/logic/commands/SearchCommandTest.java
+++ b/src/test/java/trackup/logic/commands/SearchCommandTest.java
@@ -102,7 +102,7 @@ public class SearchCommandTest {
         expectedModel.updateFilteredPersonList(p -> false); // No matches
 
         assertCommandSuccess(searchCommand, model,
-                String.format(SearchCommand.MESSAGE_SUCCESS, "Nonexistent Keyword"), expectedModel);
+                String.format(SearchCommand.MESSAGE_NO_MATCH, "Nonexistent Keyword"), expectedModel);
     }
 
     @Test


### PR DESCRIPTION
Closes #135 

### Changes

- SearchCommand now returns `No matching person found with: no_match_keyword` with keyword that has no matches in contact list.
- SearchCommandTest is updated to account for above change.