### PR TITLE
fix: Edit FindCommand to display suitable message for no matches

### DIFF
--- a/src/main/java/trackup/logic/Messages.java
+++ b/src/main/java/trackup/logic/Messages.java
@@ -16,7 +16,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person(s) listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_END_BEFORE_START = "End datetime provided is before start datetime";

--- a/src/main/java/trackup/logic/commands/FindCommand.java
+++ b/src/main/java/trackup/logic/commands/FindCommand.java
@@ -20,6 +20,8 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
+    public static final String MESSAGE_NO_MATCH = "No matching person found";
+
     private final NameContainsKeywordsPredicate predicate;
 
     public FindCommand(NameContainsKeywordsPredicate predicate) {
@@ -30,6 +32,11 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+
+        if (model.getFilteredPersonList().isEmpty()) {
+            return new CommandResult(String.format(MESSAGE_NO_MATCH));
+        }
+
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/test/java/trackup/logic/commands/FindCommandTest.java
+++ b/src/test/java/trackup/logic/commands/FindCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static trackup.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static trackup.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static trackup.logic.commands.FindCommand.MESSAGE_NO_MATCH;
 import static trackup.testutil.TypicalPersons.CARL;
 import static trackup.testutil.TypicalPersons.ELLE;
 import static trackup.testutil.TypicalPersons.FIONA;
@@ -56,7 +57,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_NO_MATCH, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);


### PR DESCRIPTION
Closes #136 

### Changes

- Find Command now returns `No matching person found` with keyword that has no matches in contact list.
- FindCommandTest is updated to account for above change.
- MESSAGE_PERSONS_LISTED_OVERVIEW now display person(s) instead of persons