### PR TITLE
Bug: Fix SortCommand parsing issues

### DIFF
--- a/src/main/java/trackup/logic/parser/SortCommandParser.java
+++ b/src/main/java/trackup/logic/parser/SortCommandParser.java
@@ -28,6 +28,9 @@ import trackup.model.person.Person;
  */
 public class SortCommandParser implements Parser<SortCommand> {
 
+    private static final String INVALID_SORT_VALUE_MESSAGE =
+            "Invalid sort order for prefix '%s': '%s'. Expected 'true' or 'false' (case-insensitive).";
+
     /**
      * Parses the given {@code String} of arguments in the context of the SortCommand
      * and returns a SortCommand object for execution.
@@ -53,10 +56,16 @@ public class SortCommandParser implements Parser<SortCommand> {
         for (Prefix prefix : comparatorMap.keySet()) {
             Optional<String> valueOpt = argMultimap.getValue(prefix);
             if (valueOpt.isPresent()) {
-                boolean isDescending = Boolean.parseBoolean(valueOpt.get().strip());
+                String rawValue = valueOpt.get().strip();
+                String value = rawValue.toLowerCase();
+                if (!value.equals("true") && !value.equals("false")) {
+                    throw new ParseException(String.format(INVALID_SORT_VALUE_MESSAGE, prefix.getPrefix(), rawValue));
+                }
+
+                boolean isDescending = Boolean.parseBoolean(value);
                 Comparator<Person> comparator = comparatorMap.get(prefix);
                 Integer index = args.indexOf(prefix.getPrefix());
-                comparators.add(new Pair<>(index, isDescending ? comparator : comparator.reversed()));
+                comparators.add(new Pair<>(index, isDescending ? comparator.reversed() : comparator));
             }
         }
 

--- a/src/main/java/trackup/logic/parser/SortCommandParser.java
+++ b/src/main/java/trackup/logic/parser/SortCommandParser.java
@@ -14,7 +14,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 import javafx.util.Pair;
 import trackup.logic.commands.SortCommand;
@@ -78,7 +77,8 @@ public class SortCommandParser implements Parser<SortCommand> {
         Comparator<Person> finalComparator = comparators.stream()
                 .map(Pair::getValue)
                 .reduce(Comparator::thenComparing)
-                .orElseThrow(() -> new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE)));
+                .orElseThrow(() -> new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE)));
 
         return new SortCommand(finalComparator);
     }

--- a/src/test/java/trackup/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/trackup/logic/parser/SortCommandParserTest.java
@@ -58,8 +58,7 @@ public class SortCommandParserTest {
     public void parse_missingBooleanValue_throwsParseException() throws ParseException {
         // Test missing boolean value
         Comparator<?> expected = Comparators.NAME_COMPARATOR;
-        SortCommand command = parser.parse(" " + PREFIX_NAME);
-        assertEquals(expected, command.getComparator());
+        assertThrows(ParseException.class, () -> parser.parse(" " + PREFIX_NAME));
     }
 
     @Test


### PR DESCRIPTION
- Fix bug where prefix argument included rest of the argument string from prefix position
- Fix bug where all argument value not equals "true" is treated as false (now throws ParseException)
- Some refactoring

Closes: https://github.com/AY2425S2-CS2103T-F14-4/tp/issues/146 and https://github.com/AY2425S2-CS2103T-F14-4/tp/issues/147