### PR TITLE
fix: Edit handlePreviousWeek and handleNextWeek to correctly create month year label

### DIFF
--- a/src/main/java/trackup/ui/MainWindow.java
+++ b/src/main/java/trackup/ui/MainWindow.java
@@ -306,7 +306,12 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handlePreviousWeek() {
         calendarView.showPreviousWeek();
-        updateMonthYearLabel(calendarView.getCurrentWeekStart());
+        if (calendarView.getCurrentDate().isAfter(calendarView.getCurrentWeekStart())
+            && calendarView.getCurrentDate().isBefore(calendarView.getCurrentWeekStart().plusDays(6))) {
+            updateMonthYearLabel(calendarView.getCurrentDate());
+        } else {
+            updateMonthYearLabel(calendarView.getCurrentWeekStart());
+        }
     }
 
     /**
@@ -315,7 +320,12 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleNextWeek() {
         calendarView.showNextWeek();
-        updateMonthYearLabel(calendarView.getCurrentWeekStart());
+        if (calendarView.getCurrentDate().isAfter(calendarView.getCurrentWeekStart())
+                && calendarView.getCurrentDate().isBefore(calendarView.getCurrentWeekStart().plusDays(6))) {
+            updateMonthYearLabel(calendarView.getCurrentDate());
+        } else {
+            updateMonthYearLabel(calendarView.getCurrentWeekStart());
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #149 

### Changes

- Edit handlePreviousWeek to check if the current date falls within a one-week range for the switched week and create correct month year label
- Edit handleNextWeek to check if the current date falls within a one-week range for the switched week and create correct month year label
