### PR TITLE
fix: Add larger padding for category label

### DIFF
--- a/src/main/java/trackup/ui/PersonCard.java
+++ b/src/main/java/trackup/ui/PersonCard.java
@@ -80,7 +80,7 @@ public class PersonCard extends UiPart<Region> {
             category.setVisible(visibility.isShowCategory());
             String categoryColor = getCategoryColor(categoryName);
             category.setStyle("-fx-background-color: #3B3B3B;"
-                    + "-fx-text-fill: " + categoryColor + "); -fx-border-radius: 5px; -fx-padding: 1px 2px;");
+                    + "-fx-text-fill: " + categoryColor + "); -fx-border-radius: 5px; -fx-padding: 1px 4px;");
             cardPane.setStyle("-fx-border-color: " + categoryColor + ");" + "-fx-border-width: 2px;"
                     + "-fx-background-color: " + categoryColor + ", 0.1);"); // 10% opacity
         } else {


### PR DESCRIPTION
Closes #172 

### Changes
- Edit PersonCard.java to give category label a larger breathing space by adding bigger padding
- Originally, `-fx-padding: 1px 2px;` to `-fx-padding: 1px 4px;`

### Screenshot
![Screenshot 2025-04-06 at 1 30 32 PM](https://github.com/user-attachments/assets/e66316c7-9e42-4d04-9d8c-d8f671a622ee)
