### PR TITLE
fix: Edit tag label to have max width and wrapping enabled

### DIFF
--- a/src/main/java/trackup/ui/PersonCard.java
+++ b/src/main/java/trackup/ui/PersonCard.java
@@ -71,6 +71,9 @@ public class PersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> {
                     Label label = new Label(tag.tagName);
+                    label.setWrapText(true);
+                    label.setMaxWidth(310);
+                    label.setMinHeight(Region.USE_PREF_SIZE);
                     label.setVisible(visibility.isShowTag());
                     tags.getChildren().add(label);
                 });


### PR DESCRIPTION
Closes #175 

### Changes
- PersonCard.java : Edit tag label text to have max width and wrapping enabled so that label does not grow over the person card GUI

### Screenshot
![Screenshot 2025-04-06 at 1 52 47 PM](https://github.com/user-attachments/assets/65e2332d-b4fd-4462-9738-161554cbafc2)
