### PR TITLE
Fix clear command message to reflect product name 'TrackUp'

### DIFF
--- a/src/main/java/trackup/logic/commands/ClearCommand.java
+++ b/src/main/java/trackup/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import trackup.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "TrackUp has been cleared!";
 
 
     @Override


### PR DESCRIPTION
Fixes #184.

Updated the success message in ClearCommand from "Address book has been cleared!" to "TrackUp has been cleared!" for consistency with the product name. 