### PR TITLE
Disallow numeric-only names in AddCommand

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -153,8 +153,11 @@ Format: `sort [-n <BOOLEAN>] [-p <BOOLEAN>] [-e <BOOLEAN>] [-a <BOOLEAN>] [-c <B
 **Examples:**
 - `sort` — displays all contacts.
 - `sort -n true` — displays result list of contacts sorted by name in descending order.
-- `sort -t -n true` — displays result list of contacts first sorted by tag in ascending order,
-then sorted by name in descending order
+
+**Notes:**
+- TrackUp currently supports sorting by only one field at a time.
+  Compound sorting like `sort -t -n true` is not supported.
+
 
 ### Editing a person : `edit`
 
@@ -452,22 +455,22 @@ Editing the data file incorrectly may cause TrackUp to discard all data or behav
 
 ## Command Summary
 
-| **Action**                | **Format, Examples**                                                                                                                                                                 |
-|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Viewing help**          | `help [<COMMAND_WORD>]`  <br> e.g., `help`, `help add`, `help delete`                                                                                                                |
-| **Adding a person**       | `add -n <NAME> -p <PHONE> -e <EMAIL> -a <ADDRESS> [-c <CATEGORY>] [-t <TAG>]...`  <br> e.g., `add -n John Doe -p 98765432 -e johnd@example.com -a John street -c Client -t friend`   |
-| **Deleting a person**     | `delete <INDEX>`  <br> e.g., `delete 3`, `list` followed by `delete 2`, `find Betsy` followed by `delete 1`                                                                          |
-| **Deleting by attribute** | `deleteby [-n <NAME>] [-p <PHONE>] [-e <EMAIL>] [-a <ADDRESS>] [-c <CATEGORY>] [-t <TAG>]`  <br> e.g., `deleteby -n John Doe`, `deleteby -p 98765432`                                |
-| **Editing a person**      | `edit <INDEX> [-n <NAME>] [-p <PHONE>] [-e <EMAIL>] [-a <ADDRESS>] [-c <CATEGORY>] [-t <TAG>]...`  <br> e.g., `edit 1 -p 91234567 -e johnd@example.com`                              |
-| **Listing persons**       | `list [<CATEGORY>]`  <br> e.g., `list`, `list Client`, `list Investor`                                                                                                               |
-| **Sorting persons**       | `sort [-n <BOOLEAN>] [-p <BOOLEAN>] [-e <BOOLEAN>] [-a <BOOLEAN>] [-c <BOOLEAN>] [-t <BOOLEAN>]`  <br> e.g., `sort`, `sort -n true`, `sort -t -n true`                               |
-| **Finding by name**       | `find KEYWORD [MORE_KEYWORDS]`  <br> e.g., `find John`, `find alex david`                                                                                                            |
-| **Searching persons**     | `search <KEYWORD>`  <br> e.g., `search John`, `search 98765432`, `search Clementi`, `search doe`                                                                                     |
+| **Action**                | **Format, Examples**                                                                                                                                                                |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Viewing help**          | `help [<COMMAND_WORD>]`  <br> e.g., `help`, `help add`, `help delete`                                                                                                               |
+| **Adding a person**       | `add -n <NAME> -p <PHONE> -e <EMAIL> -a <ADDRESS> [-c <CATEGORY>] [-t <TAG>]...`  <br> e.g., `add -n John Doe -p 98765432 -e johnd@example.com -a John street -c Client -t friend`  |
+| **Deleting a person**     | `delete <INDEX>`  <br> e.g., `delete 3`, `list` followed by `delete 2`, `find Betsy` followed by `delete 1`                                                                         |
+| **Deleting by attribute** | `deleteby [-n <NAME>] [-p <PHONE>] [-e <EMAIL>] [-a <ADDRESS>] [-c <CATEGORY>] [-t <TAG>]`  <br> e.g., `deleteby -n John Doe`, `deleteby -p 98765432`                               |
+| **Editing a person**      | `edit <INDEX> [-n <NAME>] [-p <PHONE>] [-e <EMAIL>] [-a <ADDRESS>] [-c <CATEGORY>] [-t <TAG>]...`  <br> e.g., `edit 1 -p 91234567 -e johnd@example.com`                             |
+| **Listing persons**       | `list [<CATEGORY>]`  <br> e.g., `list`, `list Client`, `list Investor`                                                                                                              |
+| **Sorting persons**       | `sort [-n <BOOLEAN>] [-p <BOOLEAN>] [-e <BOOLEAN>] [-a <BOOLEAN>] [-c <BOOLEAN>] [-t <BOOLEAN>]`  <br> e.g., `sort`, `sort -n true`                             |
+| **Finding by name**       | `find KEYWORD [MORE_KEYWORDS]`  <br> e.g., `find John`, `find alex david`                                                                                                           |
+| **Searching persons**     | `search <KEYWORD>`  <br> e.g., `search John`, `search 98765432`, `search Clementi`, `search doe`                                                                                    |
 | **Adding an event**       | `addevent -t <EVENT_TITLE> -s <START_DATETIME> -e <END_DATETIME> [-c <CONTACT_INDEX>]...`  <br> e.g., `addevent -t "Team Meeting" -s 2025-03-30 14:00 -e 2025-03-30 15:00 -c 1 -c 3` |
-| **Deleting an event**     | `delevent [-t <TITLE_KEYWORD>] [-s <START_DATETIME>] [-e <END_DATETIME>] [-c <CONTACT_INDEX>]...`  <br> e.g., `delevent -t Meeting`, `delevent -c 2`                                 |
-| **Adding a note**         | `addnote <PERSON_INDEX> <NOTE_TEXT>`  <br> e.g., `addnote 1 Met at tech networking event`, `addnote 2 Follow up next week regarding proposal`                                        |
-| **Deleting a note**       | `delnote <PERSON_INDEX> <NOTE_INDEX>`  <br> e.g., `delnote 2 1`, `find John` followed by `delnote 1 2`                                                                               |
-| **Toggling visibility**   | `toggle <FIELD>`  <br> e.g., `toggle name`, `toggle phone`, `toggle note`, `toggle datetime`                                                                                         |
-| **Clearing all entries**  | `clear`                                                                                                                                                                              |
-| **Exiting the program**   | `exit`                                                                                                                                                                               |
+| **Deleting an event**     | `delevent [-t <TITLE_KEYWORD>] [-s <START_DATETIME>] [-e <END_DATETIME>] [-c <CONTACT_INDEX>]...`  <br> e.g., `delevent -t Meeting`, `delevent -c 2`                                |
+| **Adding a note**         | `addnote <PERSON_INDEX> <NOTE_TEXT>`  <br> e.g., `addnote 1 Met at tech networking event`, `addnote 2 Follow up next week regarding proposal`                                       |
+| **Deleting a note**       | `delnote <PERSON_INDEX> <NOTE_INDEX>`  <br> e.g., `delnote 2 1`, `find John` followed by `delnote 1 2`                                                                              |
+| **Toggling visibility**   | `toggle <FIELD>`  <br> e.g., `toggle name`, `toggle phone`, `toggle note`, `toggle datetime`                                                                                        |
+| **Clearing all entries**  | `clear`                                                                                                                                                                             |
+| **Exiting the program**   | `exit`                                                                                                                                                                              |
 

--- a/src/main/java/trackup/model/person/Name.java
+++ b/src/main/java/trackup/model/person/Name.java
@@ -10,13 +10,15 @@ import static trackup.commons.util.AppUtil.checkArgument;
 public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should contain at least one alphabet character, "
+                    + "and only contain alphanumeric characters and spaces. It should not be blank.";
+
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "(?=.*[A-Za-z])[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String fullName;
 

--- a/src/test/java/trackup/model/person/NameTest.java
+++ b/src/test/java/trackup/model/person/NameTest.java
@@ -29,11 +29,15 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("123456")); // numbers only — now invalid
+        assertFalse(Name.isValidName("11")); // numeric only — now invalid
+        assertFalse(Name.isValidName("123 456")); // numbers and space
+
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
+        assertTrue(Name.isValidName("John 123")); // mix of letters and numbers
+        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters still valid
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
     }


### PR DESCRIPTION
Fixes #177

- Updated validation in `Name.java` to disallow names made up of only digits.
- Added regex pattern to enforce at least one alphabet character in names.
- Adjusted test cases in `NameTest.java` to reflect new constraint.
- Reason: Prevents user confusion with phone numbers and ensures meaningful contact entries.
