### PR TITLE
Disallow numeric-only names in AddCommand (cherry-pick)

### DIFF
--- a/src/main/java/trackup/model/person/Name.java
+++ b/src/main/java/trackup/model/person/Name.java
@@ -10,13 +10,15 @@ import static trackup.commons.util.AppUtil.checkArgument;
 public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should contain at least one alphabet character, "
+                    + "and only contain alphanumeric characters and spaces. It should not be blank.";
+
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "(?=.*[A-Za-z])[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String fullName;
 

--- a/src/test/java/trackup/model/person/NameTest.java
+++ b/src/test/java/trackup/model/person/NameTest.java
@@ -29,11 +29,15 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("123456")); // numbers only — now invalid
+        assertFalse(Name.isValidName("11")); // numeric only — now invalid
+        assertFalse(Name.isValidName("123 456")); // numbers and space
+
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
+        assertTrue(Name.isValidName("John 123")); // mix of letters and numbers
+        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters still valid
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
     }


### PR DESCRIPTION
Fixes #177

- Updated validation in `Name.java` to disallow names made up of only digits.
- Added regex pattern to enforce at least one alphabet character in names.
- Adjusted test cases in `NameTest.java` to reflect new constraint.
- Reason: Prevents user confusion with phone numbers and ensures meaningful contact entries.

An earlier PR by me fixed this but closed it as it contained unrelated commits. 