### PR TITLE
Fix misleading error for invalid category in list command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -122,7 +122,7 @@ How the parsing works:
 * All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible e.g, during testing.
 
 ### `AddCommandParser` Logic Enhancement
-- The `AddCommandParser` validates required fields (name, phone, email, address) individually 
+- The `AddCommandParser` validates required fields (name, phone, email, address) individually
   and throws descriptive error messages for each missing attribute.
 - This improves user feedback and avoids a generic format error.
 
@@ -274,7 +274,7 @@ _{more aspects and alternatives to be added}_
 
 To provide users with more informative feedback during failed deletions (e.g., due to contact links in events), we plan to enhance the `DeleteCommand` and `DeleteByCommand` classes to inspect references before deletion.
 
-The command will throw a `CommandException` with a message such as:  
+The command will throw a `CommandException` with a message such as:
 `"The contact Amy Lee could not be deleted as it is referenced by event: Pitch Call with Investors."`
 
 This prevents silent failure and helps users take corrective action quickly.
@@ -300,7 +300,7 @@ The following enhancements are planned for upcoming iterations:
 
 1. **More Specific Error Messages for Contact Deletion**
     - *Current Behavior*: Shows a generic failure message.
-    - *Planned*: Display messages like  
+    - *Planned*: Display messages like
       `"The contact Amy Lee could not be deleted as it is referenced by another contact Ben Chua."`
     - *Reason*: Improves clarity and user understanding.
 
@@ -314,7 +314,7 @@ The following enhancements are planned for upcoming iterations:
 
 These were considered but not implemented for v1.6:
 
-- **Automatic Merging of Duplicate Contacts**  
+- **Automatic Merging of Duplicate Contacts**
   Rejected due to complexity in detecting semantic duplicates.
 
 ## **Documentation, logging, testing, configuration, dev-ops**
@@ -447,7 +447,7 @@ These were considered but not implemented for v1.6:
 2. TrackUp displays the list of contacts.
 3. User requests to edit a specific contact in the list, specifying the new details.
 4. TrackUp updates the contact's details.
-5. TrackUp displays a confirmation message.  
+5. TrackUp displays a confirmation message.
    Use case ends.
 
 #### Extensions
@@ -475,7 +475,7 @@ These were considered but not implemented for v1.6:
 1. User requests to list contacts.
 2. TrackUp displays a list of contacts.
 3. User requests to delete a specific contact in the list.
-4. TrackUp deletes the contact and displays a confirmation message.  
+4. TrackUp deletes the contact and displays a confirmation message.
    Use case ends.
 
 #### Extensions
@@ -497,18 +497,18 @@ These were considered but not implemented for v1.6:
 ### Use Case: Add an Event
 
 #### Main Success Scenario (MSS)
-1. User requests to add an event. 
+1. User requests to add an event.
 2. TrackUp creates the event and links the specified contacts.
-3. TrackUp updates the weekly calendar view to display the new event. 
-4. TrackUp displays a confirmation message.  
+3. TrackUp updates the weekly calendar view to display the new event.
+4. TrackUp displays a confirmation message.
 Use case ends.
 
 #### Extensions
-- 1a. The start datetime is after the end datetime. 
+- 1a. The start datetime is after the end datetime.
   - 1a1. TrackUp shows an error message: `"End datetime provided is before start datetime"`
   - Use case resumes at step 1.
 
-- 1b. One or more specified contact indices are invalid. 
+- 1b. One or more specified contact indices are invalid.
   - 1b1. TrackUp shows an error message: `"The person index provided is invalid"`
   - Use case resumes at step 1.
 
@@ -521,11 +521,11 @@ Use case ends.
 2. TrackUp finds all matching events.
 3. TrackUp deletes all occurrences of the matching events.
 4. TrackUp updates the weekly calendar view to remove the deleted events.
-5. TrackUp displays a confirmation message.   
+5. TrackUp displays a confirmation message.
 Use case ends.
 
 #### Extensions
-- 2a. No matching events are found. 
+- 2a. No matching events are found.
   - 2a1. TrackUp shows a message: `"No matching events found."`
   - Use case ends.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -3,7 +3,7 @@ layout: page
 title: User Guide
 ---
 
-**TrackUp** is a **desktop application for managing contacts and events** that is optimised for a CLI-first experience while still offering the benefits of a GUI. 
+**TrackUp** is a **desktop application for managing contacts and events** that is optimised for a CLI-first experience while still offering the benefits of a GUI.
 
 Designed for startup founders, **TrackUp** streamlines relationship management, follow-ups, and event organisation — helping you work efficiently without unnecessary distractions.
 
@@ -28,16 +28,16 @@ TrackUp needs **Java** (version 17 or higher) to run.
    * This folder will be where TrackUp stores its data.
 
 4. **Open TrackUp**<br>
-   * Open the **Terminal** (on Mac) or **Command Prompt** (on Windows).   
-   * Go to the folder where you put the .jar file. To do that, type: `cd path-to-the-folder`  
-   (Replace “path-to-the-folder” with the actual folder location)  
-   * Then start the app by typing: `java -jar trackup.jar`  
+   * Open the **Terminal** (on Mac) or **Command Prompt** (on Windows).
+   * Go to the folder where you put the .jar file. To do that, type: `cd path-to-the-folder`
+   (Replace “path-to-the-folder” with the actual folder location)
+   * Then start the app by typing: `java -jar trackup.jar`
    * After a few seconds, the application will open with a window like this:
    ![Ui](images/Ui.png)
 
 5. **Try a command**<br>
    * Click on the command box at the top left of the application window.
-   * Type a command like this: `help` and pressing Enter will open the help window.  
+   * Type a command like this: `help` and pressing Enter will open the help window.
    * Here are a few more example commands you can try:
      * `list` - Lists all contacts.
      * `add -n John Doe -p 98765432 -e johnd@example.com -a John street, block 123, #01-01` - Adds a contact named `John Doe` to the Address Book.
@@ -68,7 +68,7 @@ TrackUp needs **Java** (version 17 or higher) to run.
 
 ### Viewing help : `help`
 
-Shows a message to access the help page.  
+Shows a message to access the help page.
 Shows the list of all commands, or full usage when a specific command is given.
 
 ![help message](images/helpMessage.png)
@@ -317,7 +317,7 @@ Format: `delnote <PERSON_INDEX> <NOTE_INDEX>`
 
 ### Toggling field visibility: `toggle`
 
-Toggles the visibility of a specific field in the TrackUp contact list UI.  
+Toggles the visibility of a specific field in the TrackUp contact list UI.
 This command is useful for customising the information you want displayed for each contact.
 
 Format: `toggle <FIELD>`
@@ -384,7 +384,7 @@ Format: `delnote <PERSON_INDEX> <NOTE_INDEX>`
 
 ### Toggling field visibility: `toggle`
 
-Toggles the visibility of a specific field in the TrackUp contact list UI.  
+Toggles the visibility of a specific field in the TrackUp contact list UI.
 This command is useful for customizing the information you want displayed for each contact.
 
 Format: `toggle <FIELD>`

--- a/src/main/java/trackup/logic/parser/ListCommandParser.java
+++ b/src/main/java/trackup/logic/parser/ListCommandParser.java
@@ -25,8 +25,10 @@ public class ListCommandParser implements Parser<ListCommand> {
         if (!trimmedArgs.isEmpty()) {
             trimmedArgs = trimmedArgs.substring(0, 1).toUpperCase() + trimmedArgs.substring(1).toLowerCase();
             if (!Category.isValidCategoryName(trimmedArgs)) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+                throw new ParseException("Invalid category: '" + trimmedArgs
+                        + "'. Use one of the supported categories: Client, Partner, Investor, Other.");
             }
+
             category = Optional.of(new Category(trimmedArgs));
         }
 

--- a/src/main/java/trackup/logic/parser/ListCommandParser.java
+++ b/src/main/java/trackup/logic/parser/ListCommandParser.java
@@ -1,7 +1,5 @@
 package trackup.logic.parser;
 
-import static trackup.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import java.util.Optional;
 
 import trackup.logic.commands.ListCommand;


### PR DESCRIPTION
Previously, when users typed `list Friends`, the app incorrectly displayed a generic "Invalid command format!" message. This fix improves the user experience by showing a more descriptive message such as:

Invalid category: 'Friends'. Use one of the supported categories: Client, Partner, Investor, Other.

Fixes PE-D Issue #165.
